### PR TITLE
BUGFIX: PHPUnit dependency pinned to ~5.2.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -25,7 +25,7 @@
     "require-dev": {
         "typo3/buildessentials": "~2.3.0",
         "mikey179/vfsstream": "~1.6",
-        "phpunit/phpunit": "~4.8 || ~5.0",
+        "phpunit/phpunit": "~4.8 || ~5.2.0",
         "flowpack/behat": "dev-master"
     },
     "suggest": {


### PR DESCRIPTION
Due to the incopatibility with PHPUnit 5.3.x we pin the dependency 
to "~4.8 || ~5.2.0" until we find a solution.

FLOW-447 #comment neos-base-distribution updated
