### PR TITLE
TASK: Update requirement of neos/neos-ui* to stable version

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -20,10 +20,6 @@
         "neos/nodetypes": "~4.0.0",
         "neos/demo": "~4.0.0",
         "neos/site-kickstarter": "~4.0.0",
-
-        "neos/neos-ui": "1.0.*@beta",
-        "neos/neos-ui-compiled": "1.0.*@beta",
-
         "neos/seo": "~2.0",
         "neos/setup": "~4.0",
         "flowpack/neos-frontendlogin": "~3.0",

--- a/composer.json
+++ b/composer.json
@@ -20,6 +20,8 @@
         "neos/nodetypes": "~4.0.0",
         "neos/demo": "~4.0.0",
         "neos/site-kickstarter": "~4.0.0",
+        "neos/neos-ui": "^1.0",	
+        "neos/neos-ui-compiled": "^1.0",
         "neos/seo": "~2.0",
         "neos/setup": "~4.0",
         "flowpack/neos-frontendlogin": "~3.0",


### PR DESCRIPTION
As the new react backend has become default, it should be required by neos/neos directly.
See: https://github.com/neos/neos-development-collection/pull/2044