### PR TITLE
TASK: Remove flowpack/neos-frontendlogin from base distro

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -26,7 +26,6 @@
 
         "neos/seo": "~2.0",
         "neos/setup": "~4.0",
-        "flowpack/neos-frontendlogin": "~3.0",
         "neos/redirecthandler-neosadapter": "~2.0",
         "neos/redirecthandler-databasestorage": "~2.0"
     },


### PR DESCRIPTION
It is required via neos/demo anyway and not needed in the base distro. Has been removed for 4.0 already with #28, but wasn't upmerged to master and thus got lost.