### PR TITLE
TASK: Add DistributionPackages folder to the base-distribution

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -37,6 +37,12 @@
         "symfony/css-selector": "~2.0",
         "neos/behat": "dev-master"
     },
+    "repositories": {
+        "distributionPackages": {
+            "type": "path",
+            "url": "./DistributionPackages/*"
+        }
+    },
     "replace": {
         "typo3/neos-base-distribution": "self.version"
     },


### PR DESCRIPTION
All packages in DistributionPackages are registered in the composer file as a local repositoy and can be required.