### PR TITLE
TASK: Update dependencies of non-core Neos packages

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -18,12 +18,12 @@
     "require": {
         "neos/neos": "4.3.x-dev",
         "neos/nodetypes": "4.3.x-dev",
-        "neos/demo": "@dev",
         "neos/site-kickstarter": "4.3.x-dev",
 
-        "neos/neos-ui": "@dev",
+        "neos/demo": "~5.0.0",
+        "neos/neos-ui": "^3.3",
+        "neos/seo": "~2.1",
 
-        "neos/seo": "@dev",
         "neos/setup": "@dev",
         "neos/redirecthandler-neosadapter": "@dev",
         "neos/redirecthandler-databasestorage": "@dev",

--- a/composer.json
+++ b/composer.json
@@ -23,10 +23,10 @@
         "neos/demo": "~5.0.0",
         "neos/neos-ui": "^3.3",
         "neos/seo": "~2.1",
+        "neos/redirecthandler-neosadapter": "~3.0.0",
+        "neos/redirecthandler-databasestorage": "~3.0.0",
 
         "neos/setup": "@dev",
-        "neos/redirecthandler-neosadapter": "@dev",
-        "neos/redirecthandler-databasestorage": "@dev",
         "neos/content-repository": "4.3.x-dev",
         "neos/fusion": "4.3.x-dev",
         "neos/media": "4.3.x-dev",
@@ -46,6 +46,7 @@
             "url": "./DistributionPackages/*"
         }
     },
+    "minimum-stability": "dev",
     "replace": {
         "neos/neos-base-distribution": "self.version"
     },

--- a/composer.json
+++ b/composer.json
@@ -21,10 +21,10 @@
         "neos/site-kickstarter": "4.3.x-dev",
 
         "neos/demo": "~5.0.0",
-        "neos/neos-ui": "^3.3",
+        "neos/neos-ui": "~3.3",
         "neos/seo": "~2.1",
-        "neos/redirecthandler-neosadapter": "~3.0.0",
-        "neos/redirecthandler-databasestorage": "~3.0.0",
+        "neos/redirecthandler-neosadapter": "~3.0",
+        "neos/redirecthandler-databasestorage": "~3.0",
 
         "neos/setup": "@dev",
         "neos/content-repository": "4.3.x-dev",


### PR DESCRIPTION
Set the dependencies for packages that are maintained outside the neos core for the 4.3 base-distribution:

```
"neos/demo": "~5.0.0",
"neos/neos-ui": "~3.3",
"neos/seo": "~2.1",
"neos/redirecthandler-neosadapter": "~3.0",
"neos/redirecthandler-databasestorage": "~3.0",
```