### PR TITLE
TASK: Update the peer dependency constraints

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -20,9 +20,10 @@
         "neos/nodetypes": "4.3.x-dev",
         "neos/site-kickstarter": "4.3.x-dev",
 
-        "neos/demo": "~5.0.0",
+        "neos/demo": "~5.0.1",
         "neos/neos-ui": "~3.3",
-        "neos/seo": "~2.1",
+        "neos/seo": "~3.0",
+        "neos/fusion-afx": "~1.2",
         "neos/redirecthandler-neosadapter": "~3.0",
         "neos/redirecthandler-databasestorage": "~3.0",
 
@@ -46,7 +47,6 @@
             "url": "./DistributionPackages/*"
         }
     },
-    "minimum-stability": "dev",
     "replace": {
         "neos/neos-base-distribution": "self.version"
     },


### PR DESCRIPTION
- neos/demo to ~5.0.1 (to allow neos demo 3)
- neos/seo to ~3.0
- neos/fusion-afx ~1.2 (new but we sell it as part of the default)

In addition this removes an accidentally committed `minimumStability` rule.