### PR TITLE
!!! TASK: Remove dependency to Neos.Nodetypes

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,6 @@
     },
     "require": {
         "neos/neos": "~4.3.0",
-        "neos/nodetypes": "~4.3.0",
         "neos/site-kickstarter": "~4.3.0",
 
         "neos/demo": "~5.0.1",


### PR DESCRIPTION
Neos.NodeTypes is deprecated but also not needed as dependency of the the distribution as Neos.Demo requires the parts that it actually uses and other site-packages should do the same.

With this change and  https://github.com/neos/Neos.Demo/pull/64 a fresh Neos should finally come without Neos.NodeTypes.