### PR TITLE
TASK: Update redirecthandler version constraints and add redirecthandler-ui for Neos 5

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -23,9 +23,10 @@
         "neos/neos-ui": "~3.3",
         "neos/seo": "~3.0",
         "neos/fusion-afx": "~1.2",
-        "neos/redirecthandler-neosadapter": "~3.0",
-        "neos/redirecthandler-databasestorage": "~3.0",
-        
+        "neos/redirecthandler-neosadapter": "~4.0",
+        "neos/redirecthandler-databasestorage": "~4.0",
+        "neos/redirecthandler-ui": "~2.0",
+
         "neos/setup": "@dev",
         "neos/neos-setup": "@dev",
         "neos/nodetypes": "5.0.x-dev",


### PR DESCRIPTION
This is blocked by https://github.com/neos/redirecthandler-ui/issues/26 but as soon as this is solved the redirecthandler-ui should become default part of the neos distribution as the other redirecthandler packages already are. 