### PR TITLE
TASK: Remove neos/nodetypes dependency from 5.0 branch

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -29,7 +29,6 @@
         
         "neos/setup": "@dev",
         "neos/neos-setup": "@dev",
-        "neos/nodetypes": "5.0.x-dev",
         "neos/content-repository": "5.0.x-dev",
         "neos/fusion": "5.0.x-dev",
         "neos/media": "5.0.x-dev",


### PR DESCRIPTION
This must have been added here by some automation during branching that should be removed aswell. Also we should make sure this is not added again during releasing.