### PR TITLE
FEATURE: Remove already included packages

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -22,8 +22,6 @@
         "neos/demo": "@dev",
         "neos/neos-ui": "@dev",
         "neos/seo": "@dev",
-        "neos/fusion-afx": "@dev",
-        "neos/fusion-form": "@dev",
         "neos/redirecthandler-neosadapter": "@dev",
         "neos/redirecthandler-databasestorage": "@dev",
 


### PR DESCRIPTION
Because of https://github.com/neos/neos-development-collection/pull/2808 we don't need `neos/fusion-afx` and `neos/fusion-form` here anymore, as they will come already with `neos/neos`