### PR TITLE
BUGFIX: Remove neos/nodetypes dependency

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -27,8 +27,7 @@
         "neos/redirecthandler-ui": "~2.0",
 
         "neos/setup": "@dev",
-        "neos/neos-setup": "@dev",
-        "neos/nodetypes": "~5.1.0"
+        "neos/neos-setup": "@dev"
     },
     "require-dev": {
         "neos/buildessentials": "@dev",


### PR DESCRIPTION
That is no longer a dependency as of 5.0 and sneaked in due to
a buggy release tool borked by a forgotten upmerge.

Cause fixed with https://github.com/neos/neos-development-distribution/commit/757f3e867e7093f1b393423e3ca6def7db969836