### PR TITLE
TASK: Update neos-ui to 4.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -21,7 +21,7 @@
         "neos/site-kickstarter": "~4.3.0",
 
         "neos/demo": "~5.0.1",
-        "neos/neos-ui": "~3.3",
+        "neos/neos-ui": "~4.0",
         "neos/seo": "~3.0",
         "neos/fusion-afx": "~1.2",
         "neos/redirecthandler-neosadapter": "~3.0",


### PR DESCRIPTION
As we deprecated the 3.x branch in the ui we should also not use it in the base distribution. The current branch for neos 4.3 is 4.0