### PR TITLE
BUGFIX: Add composer.json allow-plugins

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -48,6 +48,10 @@
     "suggest": {
         "ext-pdo_sqlite": "For running functional tests out-of-the-box this is required"
     },
+    "allow-plugins": {
+        "neos/composer-plugin": true,
+        "composer/package-versions-deprecated": true
+    },
     "scripts": {
         "post-update-cmd": "Neos\\Flow\\Composer\\InstallerScripts::postUpdateAndInstall",
         "post-install-cmd": "Neos\\Flow\\Composer\\InstallerScripts::postUpdateAndInstall",


### PR DESCRIPTION
fixes: https://github.com/neos/flow-development-collection/issues/2757
fixes: https://discuss.neos.io/t/composer-2-2-installer-allow-plugins-requirement/5794

------

i think we should merge this fast into 5.3 and then upmerge this change, so when people try out Neos8 they can create packages ... [issue](https://github.com/neos/flow-development-collection/issues/2757)

-----

slack thread if found by @mficzel https://neos-project.slack.com/archives/C04PYL8H3/p1642587612009700

> Short question ... i would like to add
> ````
> "allow-plugins": {
>     "composer/package-versions-deprecated": true,
>     "neos/composer-plugin": true
> }
> ````
> to the composer yaml of the distributions but wonder wether this should be done for older versions aswell. So aim at 5.3 or master? What do you think?

> I assume the existence of that block automatically denies everything else?
> then I would consider that a breaking change

> No, composer will ask for anything not on there…
> https://getcomposer.org/doc/06-config.md#allow-plugins




