### PR TITLE
TASK: Use the setup command after create project

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -55,7 +55,7 @@
         "composer/package-versions-deprecated": true
     },
     "scripts": {
-        "post-create-project-cmd": "./flow welcome",
+        "post-create-project-cmd": "./flow setup:index",
         "post-update-cmd": "Neos\\Flow\\Composer\\InstallerScripts::postUpdateAndInstall",
         "post-install-cmd": "Neos\\Flow\\Composer\\InstallerScripts::postUpdateAndInstall",
         "post-package-update": "Neos\\Flow\\Composer\\InstallerScripts::postPackageUpdateAndInstall",


### PR DESCRIPTION
As we removed the welcome command, why should we still use it, although it works as an alias.

`./flow setup ` is the new command!